### PR TITLE
Update maven-shade-plugin artifact version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
The version used in the pom.xml by this project was very old (Aug 19, 2017). The new one , which i've picked is the latest stable one, and provides hundred of bugfixes and chages. I'd recommend going for this one, as it shouldn't create any issue with the current setup.