### PR TITLE
Fix Fly (C) typo in acceleration

### DIFF
--- a/src/main/java/xyz/elevated/frequency/check/impl/fly/FlyC.java
+++ b/src/main/java/xyz/elevated/frequency/check/impl/fly/FlyC.java
@@ -27,7 +27,7 @@ public final class FlyC extends PositionCheck {
         final double deltaZ = to.getZ() - from.getZ();
 
         final double horizontalDistance = Math.hypot(deltaX, deltaZ);
-        final double acceleration = Math.abs(deltaX - lastDeltaY);
+        final double acceleration = Math.abs(deltaY - lastDeltaY);
 
         final boolean exempt = this.isExempt(ExemptType.TELEPORTING, ExemptType.VELOCITY);
         final boolean touchingAir = playerData.getPositionManager().getTouchingAir().get();


### PR DESCRIPTION
This PR fixes (what I believe is) a typo in Fly (C) when declaring `acceleration`. 