### PR TITLE
Add lilliputian for Dependency Loading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
+        <repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
     </repositories>
 
     <dependencies>
@@ -85,6 +89,12 @@
             <groupId>org.atteo.classindex</groupId>
             <artifactId>classindex</artifactId>
             <version>3.6</version>
+            <scope>provided</scope>
         </dependency>
+        <dependency>
+	        <groupId>com.github.godead</groupId>
+	        <artifactId>lilliputian</artifactId>
+	        <version>0.1.13</version>
+	    </dependency>
     </dependencies>
 </project>

--- a/src/main/java/xyz/elevated/frequency/Frequency.java
+++ b/src/main/java/xyz/elevated/frequency/Frequency.java
@@ -10,6 +10,10 @@ import xyz.elevated.frequency.tick.TickManager;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import me.godead.lilliputian.Dependency;
+import me.godead.lilliputian.Lilliputian;
+import me.godead.lilliputian.Repository;
+
 @Getter
 public enum Frequency {
     INSTANCE;
@@ -24,6 +28,21 @@ public enum Frequency {
     private final Executor executorPacket = Executors.newSingleThreadExecutor();
 
     public void start(final FrequencyPlugin plugin) {
+
+        final Lilliputian lilliputian = new Lilliputian(plugin);
+        lilliputian.getDependencyBuilder()
+        .addDependency(new Dependency(
+                "https://hub.spigotmc.org/nexus/content/groups/public/",
+                "org.atteo.classindex",
+                "classindex",
+                "3.6"))
+        .addDependency(new Dependency(
+                "https://hub.spigotmc.org/nexus/content/groups/public/",
+                "org.mongodb",
+                "mongo-java-driver",
+                "3.5.0"))
+        .loadDependencies();
+        
         this.plugin = plugin;
 
         assert plugin != null : "Something went wrong! The plugin was null. (Startup)";


### PR DESCRIPTION
Reduce Jar size and enable cross-plugin dependency sharing, thus saving space on servers.

As this is meant to be a here's how to write an anticheat well I thought I had to add this.

About Lilliputian:
https://github.com/GoDead/Lilliputian

Hope you like this @ElevatedDev :D